### PR TITLE
Implement CI on MacOS via GitHub Actions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,5 +16,6 @@ jobs:
         with:
           tool_versions: >
             elixir 1.11.4-otp-23
+            erlang 23.3.2
       - run: mix deps.get
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -53,5 +53,6 @@ jobs:
         uses: asdf-vm/actions/install@v1.1.0
 
       - run: elixir --version
+      - run: mix local.hex --force
       - run: mix deps.get
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,5 +1,6 @@
 name: CI
-on: [pull_request, push]
+# TODO: add pull_request
+on: [push]
 jobs:
  mix_test:
    name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,23 +1,20 @@
 name: CI
-# TODO: add pull_request
 on: 
   push:
-  # pull_request:
+  pull_request:
   schedule:
     # run a quick build twice a week to avoid cache eviction of the erlang compilation
+    # https://github.com/actions/cache#cache-limits, at least until precompiled binaries
+    # are available for MacOS
     - cron: 0 9 * * SUN,WED
 jobs:
   mix_test:
     name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
-    # TODO: create a bi-weekly build to avoid cache eviction, or find something better like binary builds for erlang
-    # https://github.com/actions/cache#cache-limits
     strategy:
       matrix:
         erlang: ["23.2.7.2"]
         elixir: ["1.11.4-otp-23"]
-
-    # TODO: test on macos, maybe via asdf?
-    # switch to macos-11 once available (https://github.com/actions/virtual-environments/issues/2486)
+    # Note: macos-latest is currently Catalina (https://github.com/actions/virtual-environments/issues/2486)
     runs-on: macos-latest
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,15 +1,16 @@
 name: CI
 # TODO: add pull_request
 on: [push]
-# TODO: create a bi-weekly build to avoid cache eviction, or find something better like binary builds for erlang
-# https://github.com/actions/cache#cache-limits
-strategy:
-  matrix:
-    erlang: ["23.2.7.2"]
-    elixir: ["1.11.4-otp-23"]
 jobs:
   mix_test:
     name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
+    # TODO: create a bi-weekly build to avoid cache eviction, or find something better like binary builds for erlang
+    # https://github.com/actions/cache#cache-limits
+    strategy:
+      matrix:
+        erlang: ["23.2.7.2"]
+        elixir: ["1.11.4-otp-23"]
+
     # TODO: test on macos, maybe via asdf?
     # switch to macos-11 once available (https://github.com/actions/virtual-environments/issues/2486)
     runs-on: macos-latest
@@ -38,6 +39,9 @@ jobs:
             ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-elixir-${{ matrix.elixir }}
             ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-
             ${{ runner.os }}-asdf-
+
+      - name: install asdf elixir plugin
+        uses: asdf-vm/actions/plugins-add
 
       - name: asdf_install
         uses: asdf-vm/actions/install@v1.1.0

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -54,5 +54,6 @@ jobs:
 
       - run: elixir --version
       - run: mix local.hex --force
+      - run: mix local.rebar --force
       - run: mix deps.get
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,11 @@
 name: CI
 # TODO: add pull_request
-on: [push]
+on: 
+  push:
+  # pull_request:
+  schedule:
+    # run a quick build twice a week to avoid cache eviction of the erlang compilation
+    - cron: 0 9 * * SUN,WED
 jobs:
   mix_test:
     name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,14 +2,16 @@ name: CI
 # TODO: add pull_request
 on: [push]
 jobs:
- mix_test:
-   name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
-   strategy:
-     matrix:
-       elixir: ['1.12.x']
-       otp: ['23.x']
-   # TODO: switch to macos-11 once available (https://github.com/actions/virtual-environments/issues/2486)
-   runs-on: macos-latest
-   steps:
-     # https://github.com/actions/checkout
-     - uses: actions/checkout@v2
+  mix_test:
+    name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
+    # TODO: test on macos, maybe via asdf?
+    # switch to macos-11 once available (https://github.com/actions/virtual-environments/issues/2486)
+    runs-on: macos-latest
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v2
+      # https://github.com/asdf-vm/actions#main-actions
+      - name: asdf_install
+        uses: asdf-vm/actions/install@v1.1.0
+        with:
+          tool_versions: "elixir 1.11.4-otp-23"

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,9 +14,10 @@ jobs:
       - name: asdf_install
         uses: asdf-vm/actions/install@v1.1.0
         with:
-          tool_versions: >
-            elixir 1.11.4-otp-23
-            erlang 23.2.7.2
-
+          tool_versions: erlang 23.3.2
+      - name: asdf_install
+        uses: asdf-vm/actions/install@v1.1.0
+        with:
+          tool_versions: elixir 1.11.4-otp-23
       - run: mix deps.get
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -46,6 +46,6 @@ jobs:
       - name: asdf_install
         uses: asdf-vm/actions/install@v1.1.0
 
-      - run: elixir --version
+      # - run: elixir --version
       # - run: mix deps.get
       # - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,7 +8,7 @@ jobs:
        elixir: ['1.12.x']
        otp: ['23.x']
    # TODO: switch to macos-11 once available (https://github.com/actions/virtual-environments/issues/2486)
-   runs-on: macos-10
+   runs-on: macos-latest
    steps:
      # https://github.com/actions/checkout
      - uses: actions/checkout@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,4 +14,5 @@ jobs:
       - name: asdf_install
         uses: asdf-vm/actions/install@v1.1.0
         with:
-          tool_versions: "elixir 1.11.4-otp-23"
+          tool_versions: >
+            elixir 1.11.4-otp-23

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,14 @@
+name: CI
+on: [pull_request, push]
+jobs:
+ mix_test:
+   name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
+   strategy:
+     matrix:
+       elixir: ['1.12.x']
+       otp: ['23.x']
+   # TODO: switch to macos-11 once available (https://github.com/actions/virtual-environments/issues/2486)
+   runs-on: macos-10
+   steps:
+     # https://github.com/actions/checkout
+     - uses: actions/checkout@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -35,11 +35,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.ASDF_DIR }}
-          key: ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-elixir-${{ matrix.elixir }}
+          key: ${{ runner.os }}-asdf-v2-erlang-${{ matrix.erlang }}-elixir-${{ matrix.elixir }}
           restore-keys: |
-            ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-elixir-${{ matrix.elixir }}
-            ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-
-            ${{ runner.os }}-asdf-
+            ${{ runner.os }}-asdf-v2-erlang-${{ matrix.erlang }}-elixir-${{ matrix.elixir }}
+            ${{ runner.os }}-asdf-v2-erlang-${{ matrix.erlang }}-
+            ${{ runner.os }}-asdf-v2-
 
       - name: install asdf plugins
         uses: asdf-vm/actions/plugins-add@v1.1.0

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           tool_versions: >
             elixir 1.11.4-otp-23
+      - run: mix deps.get
+      - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-asdf-
 
       - name: install asdf elixir plugin
-        uses: asdf-vm/actions/plugins-add
+        uses: asdf-vm/actions/plugins-add@v1.1.0
 
       - name: asdf_install
         uses: asdf-vm/actions/install@v1.1.0

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-
             ${{ runner.os }}-asdf-
 
-      - name: install asdf elixir plugin
+      - name: install asdf plugins
         uses: asdf-vm/actions/plugins-add@v1.1.0
 
       - name: asdf_install

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,12 @@
 name: CI
 # TODO: add pull_request
 on: [push]
+# TODO: create a bi-weekly build to avoid cache eviction, or find something better like binary builds for erlang
+# https://github.com/actions/cache#cache-limits
+strategy:
+  matrix:
+    erlang: ["23.2.7.2"]
+    elixir: ["1.11.4-otp-23"]
 jobs:
   mix_test:
     name: mix test (Elixir ${{ matrix.elixir }} OTP ${{ matrix.otp }})
@@ -10,14 +16,32 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v2
-      # https://github.com/asdf-vm/actions#main-actions
+
+      # using the low-level API to ensure we can cache Erlang build
+      # https://github.com/asdf-vm/actions/issues/235#issuecomment-791924703
+
+      # https://github.com/asdf-vm/actions/blob/master/setup/action.yml
+      - name: asdf setup
+        uses: asdf-vm/actions/setup@v1.1.0
+
+      - name: generate .tool-versions file
+        run: |
+          echo "elixir ${{ matrix.elixir }}" > .tool-versions
+
+      # https://github.com/actions/cache
+      - name: asdf cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.ASDF_DIR }}
+          key: ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-elixir-${{ matrix.elixir }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-elixir-${{ matrix.elixir }}
+            ${{ runner.os }}-asdf-erlang-${{ matrix.erlang }}-
+            ${{ runner.os }}-asdf-
+
       - name: asdf_install
         uses: asdf-vm/actions/install@v1.1.0
-        with:
-          tool_versions: erlang 23.3.2
-      - name: asdf_install
-        uses: asdf-vm/actions/install@v1.1.0
-        with:
-          tool_versions: elixir 1.11.4-otp-23
-      - run: mix deps.get
-      - run: mix test
+
+      - run: elixir --version
+      # - run: mix deps.get
+      # - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -52,6 +52,6 @@ jobs:
       - name: asdf_install
         uses: asdf-vm/actions/install@v1.1.0
 
-      # - run: elixir --version
-      # - run: mix deps.get
-      # - run: mix test
+      - run: elixir --version
+      - run: mix deps.get
+      - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -53,6 +53,7 @@ jobs:
         uses: asdf-vm/actions/install@v1.1.0
 
       - run: elixir --version
+      - run: brew install portmidi
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           tool_versions: >
             elixir 1.11.4-otp-23
-            erlang 23.3.2
+            erlang 23.2.7.2
+
       - run: mix deps.get
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,6 +28,7 @@ jobs:
       - name: generate .tool-versions file
         run: |
           echo "elixir ${{ matrix.elixir }}" > .tool-versions
+          echo "erlang ${{ matrix.erlang }}" >> .tool-versions
 
       # https://github.com/actions/cache
       - name: asdf cache


### PR DESCRIPTION
This PR starts a MacOS runner (MacOS is my only use of PortMIDI right now), install `portmidi` with brew (preinstalled by GitHub), install a specific version of Erlang and Elixir with `asdf`, caches the result, and run the tests.

The Erlang build is very slow (15 minutes) due to lack of precompiled binaries on MacOS via asdf at the moment (https://github.com/asdf-vm/asdf-erlang/issues/165).

It was not possible to use the existing "install elixir" actions, because they work only on Ubuntu.

It was not possible either to use Docker, due to licensing issues, I believe it is not supported on MacOS runners at the moment.

Finally, the MacOS version is a bit old (it cannot be Big Sur yet, the default is Catalina).